### PR TITLE
Added check if default datasource is added. 

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/support/HibernateDatastoreConnectionSourcesRegistrar.groovy
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/support/HibernateDatastoreConnectionSourcesRegistrar.groovy
@@ -20,7 +20,7 @@ import org.springframework.transaction.PlatformTransactionManager
  */
 @CompileStatic
 class HibernateDatastoreConnectionSourcesRegistrar implements BeanDefinitionRegistryPostProcessor {
-
+    static final String DEFAULT_DATASOURCE_NAME = 'dataSource'
     final Iterable<String> dataSourceNames
 
     HibernateDatastoreConnectionSourcesRegistrar(Iterable<String> dataSourceNames) {
@@ -30,7 +30,7 @@ class HibernateDatastoreConnectionSourcesRegistrar implements BeanDefinitionRegi
     @Override
     void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
         for(String dataSourceName in dataSourceNames) {
-            if(dataSourceName != ConnectionSource.DEFAULT) {
+            if(dataSourceName != ConnectionSource.DEFAULT && DEFAULT_DATASOURCE_NAME != dataSourceName) {
                 String suffix = '_' + dataSourceName
                 String sessionFactoryName = "sessionFactory$suffix"
                 String transactionManagerBeanName = "transactionManager$suffix"


### PR DESCRIPTION
Added check if default datasource is added. If this isn't checked an additional transactionManager is added for the default dataSource. 
This is only necessary if you also apply the pull request of the datasourceplugin https://github.com/grails-plugins/grails-database-migration/pull/123 . This fix will ensure the default datasource is registered in the application context.  