### PR TITLE
Update constraintReference.adoc

### DIFF
--- a/docs/src/docs/asciidoc/constraints/constraintReference.adoc
+++ b/docs/src/docs/asciidoc/constraints/constraintReference.adoc
@@ -16,7 +16,7 @@ minSize,Validates that a value's size does not fall below the given minimum valu
 notEqual,Validates that that a property is not equal to the specified value,`login(notEqual: "Bob")`
 nullable,Allows a property to be set to `null` - defaults to `false`.,`age(nullable: true)`
 range,Uses a Groovy range to ensure that a property's value occurs within a specified range,`age(range: 18..65)`
-scale,Set to the desired scale for floating point numbers (i.e., the number of digits to the right of the decimal point).,`salary(scale: 2)`
+scale,Set to the desired scale for floating point numbers (i.e. the number of digits to the right of the decimal point).,`salary(scale: 2)`
 size,Uses a Groovy range to restrict the size of a collection or number or the length of a String.,`children(size: 5..15)`
 unique,Constrains a property as unique at the database level,`login(unique: true)`
 url,Validates that a String value is a valid URL.,`homePage(url: true)`


### PR DESCRIPTION
adoc tweak to fix table rendering

Additional comma was pushing all text one cell forward.

Before:
![image](https://cloud.githubusercontent.com/assets/949820/23282812/1be1a224-fa77-11e6-8a90-e81a0d7377b7.png)

After:
![image](https://cloud.githubusercontent.com/assets/949820/23282965/acad5fa0-fa77-11e6-9fb3-b9821de88ee6.png)

