### PR TITLE
fixes typo in documentation

### DIFF
--- a/docs/src/docs/asciidoc/introduction.adoc
+++ b/docs/src/docs/asciidoc/introduction.adoc
@@ -9,5 +9,5 @@ There are currently several implementations of GORM. This documentation covers t
 * http://gorm.grails.org/latest/rx/mongodb/manual[RxGORM for MongoDB]
 * http://gorm.grails.org/latest/rx/rest-client/manual[RxGORM for REST]
 
-As mentioned, GORM for Hibernate is the original implementation of GORM and has evolved dramatically over the years from a few meta-programming functions into a complete data access framework with multile implementations for different datastores relational and NoSQL.
+As mentioned, GORM for Hibernate is the original implementation of GORM and has evolved dramatically over the years from a few meta-programming functions into a complete data access framework with multiple implementations for different datastores relational and NoSQL.
 


### PR DESCRIPTION
there is a typo in 'multiple' that is fixed in this commit