### PR TITLE
a first implementation draft for grails/gorm-hibernate5#63

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-gormVersion=6.1.8.BUILD-SNAPSHOT
+gormVersion=6.1.9.BUILD-SNAPSHOT
 #gormVersion=6.1.8.RELEASE
 grailsVersion=3.2.11
 groovyVersion=2.4.11

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/MetadataIntegrator.groovy
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/MetadataIntegrator.groovy
@@ -1,0 +1,23 @@
+package org.grails.orm.hibernate
+
+import groovy.transform.CompileStatic
+import org.hibernate.boot.Metadata
+import org.hibernate.engine.spi.SessionFactoryImplementor
+import org.hibernate.integrator.spi.Integrator
+import org.hibernate.service.spi.SessionFactoryServiceRegistry
+
+@CompileStatic
+class MetadataIntegrator implements Integrator {
+
+    Metadata metadata
+
+    @Override
+    void integrate(Metadata metadata, SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+        this.metadata = metadata
+    }
+
+    @Override
+    void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+        // noop
+    }
+}

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.java
@@ -9,6 +9,7 @@ import org.grails.datastore.mapping.validation.ValidatorRegistry;
 import org.grails.orm.hibernate.EventListenerIntegrator;
 import org.grails.orm.hibernate.GrailsSessionContext;
 import org.grails.orm.hibernate.HibernateEventListeners;
+import org.grails.orm.hibernate.MetadataIntegrator;
 import org.grails.orm.hibernate.access.TraitPropertyAccessStrategy;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
@@ -251,6 +252,7 @@ public class HibernateMappingContextConfiguration extends Configuration implemen
         EventListenerIntegrator eventListenerIntegrator = new EventListenerIntegrator(hibernateEventListeners, eventListeners);
         BootstrapServiceRegistry bootstrapServiceRegistry = createBootstrapServiceRegistryBuilder()
                                                                     .applyIntegrator(eventListenerIntegrator)
+                                                                    .applyIntegrator(new MetadataIntegrator())
                                                                     .applyClassLoaderService(classLoaderService)
                                                                     .build();
         StrategySelector strategySelector = bootstrapServiceRegistry.getService(StrategySelector.class);

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/org/grails/orm/hibernate/connections/MultipleDataSourceMetadataSpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/org/grails/orm/hibernate/connections/MultipleDataSourceMetadataSpec.groovy
@@ -1,0 +1,73 @@
+package org.grails.orm.hibernate.connections
+
+import grails.persistence.Entity
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.orm.hibernate.HibernateDatastore
+import org.hibernate.boot.Metadata
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class MultipleDataSourceMetadataSpec extends Specification {
+
+    @Shared
+    Map config = [
+            "dataSources.apples.url": "jdbc:h2:mem:apples;MVCC=TRUE;LOCK_TIMEOUT=10000",
+            "dataSources.oranges.url": "jdbc:h2:mem:oranges;MVCC=TRUE;LOCK_TIMEOUT=10000"
+    ]
+
+    @AutoCleanup
+    @Shared
+    HibernateDatastore datastore = new HibernateDatastore(DatastoreUtils.createPropertyResolver(config), Apple, Orange)
+
+    void "test metadata retrieval for multiple dataSources"() {
+        when: "the metadata for the default dataSource is retrieved"
+        Metadata metadataDefault = datastore.metadata
+
+        then: "the metadata is set and does not contain entityBindings or tableMappings"
+        metadataDefault.entityBindings.size() == 0
+        metadataDefault.collectTableMappings().size() == 0
+
+        when: "the metadata for the apples dataSource is retrieved"
+        Metadata metadataApples = datastore.getDatastoreForConnection("apples").metadata
+
+        then: "the metadata is set and does contain the correct entityBinding and tableMapping"
+        metadataApples.entityBindings.size() == 1
+        metadataApples.entityBindings.first().getMappedClass() == Apple
+        metadataApples.collectTableMappings().size() == 1
+        metadataApples.collectTableMappings().first().name == "apple"
+
+        when: "the metadata for the oranges dataSource is retrieved"
+        Metadata metadataOranges = datastore.getDatastoreForConnection("oranges").metadata
+
+        then: "the metadata is set and does contain the correct entityBinding and tableMapping"
+        metadataOranges.entityBindings.size() == 1
+        metadataOranges.entityBindings.first().getMappedClass() == Orange
+        metadataOranges.collectTableMappings().size() == 1
+        metadataOranges.collectTableMappings().first().name == "orange"
+    }
+}
+
+@Entity
+class Apple {
+
+    String name
+
+    static mapping = {
+        datasource "apples"
+    }
+
+}
+
+@Entity
+class Orange {
+
+    Integer age
+
+    static mapping = {
+        datasource "oranges"
+    }
+
+}
+
+

--- a/grails-plugin/src/main/groovy/grails/plugin/hibernate/commands/SchemaExportCommand.groovy
+++ b/grails-plugin/src/main/groovy/grails/plugin/hibernate/commands/SchemaExportCommand.groovy
@@ -72,7 +72,7 @@ class SchemaExportCommand implements ApplicationCommand {
 
         def serviceRegistry = ((SessionFactoryImplementor)hibernateDatastore.sessionFactory).getServiceRegistry()
                                                                                             .getParentServiceRegistry()
-        def metadata = buildMetadata(executionContext, serviceRegistry)
+        def metadata = hibernateDatastore.metadata
 
         def schemaExport = new HibernateSchemaExport()
                 .setHaltOnError(true)
@@ -102,12 +102,4 @@ class SchemaExportCommand implements ApplicationCommand {
         return true
     }
 
-
-    protected MetadataImplementor buildMetadata(
-            ExecutionContext context,
-            ServiceRegistry serviceRegistry) throws Exception {
-        final MetadataSources metadataSources = new MetadataSources( serviceRegistry );
-        final MetadataBuilder metadataBuilder = metadataSources.getMetadataBuilder();
-        return (MetadataImplementor) metadataBuilder.build();
-    }
 }


### PR DESCRIPTION
review/feedback would be appreciated. some things to note:
* this branch originates from the 6.1.x branch and this pr also targets 6.1.x. that is because i was not able to build/publish the grails-data-mapping master locally. not sure if there is wip going on?
  * if i should rebase onto master (this can be considered an enhancement/feature) and pr to master please say so and i will further investigate whats going on with master
* i did not involve `HibernateConnectionSource` or `AbstractHibernateDatastore` in the implementation intentionally
  * those reside in `grails-data-mapping-hibernate-core` and I am not sure whats the current state there reg. compatibility with hibernate 3/4 vs. hibernate-5.2-only.
* maybe there is a better way to expose the `Metadata` (instead of using `HibernateDatastore`)?
* maybe there is a better way to pass the `Metadata` from the `MetadataIntegrator` to the place where it is exposed, instead of relying on a hibernate service registry lookup?
* if the current implementation is considered "ok", should `HibernateDatastore.getMetadataInternal()` remain `private` or better be declared `protected`?

i welcome any corrections/suggestions/improvements.

thank you!