### PR TITLE
Issue #86, Embedded properties being wrapped in proxy handling logic

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -2627,7 +2627,7 @@ public class GrailsDomainBinder implements MetadataContributor {
         setCascadeBehaviour(grailsProperty, prop);
 
         // lazy to true
-        final boolean isToOne = grailsProperty instanceof ToOne;
+        final boolean isToOne = grailsProperty instanceof ToOne && !(grailsProperty instanceof Embedded);
         PersistentEntity propertyOwner = grailsProperty.getOwner();
         boolean isLazyable = isToOne ||
                 !(grailsProperty instanceof Association) && !grailsProperty.equals(propertyOwner.getIdentity());


### PR DESCRIPTION
This is really just the same change as https://github.com/grails/grails-data-mapping/issues/1112. The code on the hibernate5 side seems to be mostly duplicated from the grails-data-mapping project.

FWIW, I'm having a hard time finding a good place to add a test case for this. I don't see any existing specs for this class and it's abstract and seems to be used in some of the sub-projects only.