### PR TITLE
allowing for application.properties in HibernateSpec

### DIFF
--- a/grails-plugin/src/main/groovy/grails/test/hibernate/HibernateSpec.groovy
+++ b/grails-plugin/src/main/groovy/grails/test/hibernate/HibernateSpec.groovy
@@ -43,6 +43,7 @@ abstract class HibernateSpec extends Specification {
         MutablePropertySources propertySources = loader.propertySources
         loader.load resourceLoader.getResource("application.yml")
         loader.load resourceLoader.getResource("application.groovy")
+        loader.load resourceLoader.getResource("application.properties")
         propertySources.addFirst(new MapPropertySource("defaults", getConfiguration()))
         Config config = new PropertySourcesConfig(propertySources)
         List<Class> domainClasses = getDomainClasses()


### PR DESCRIPTION
Enhancement that allows for `HibernateSpec` to use `application.properties` in place of `application.yml` or `application.groovy`, or allows the use of `application.properties` in conjunction with other config files.

Example: If `application.properties` is present and has a key `test.dataSource.url=jdbc:h2:mem:test2Db;`

This value can be read in `application.yml` as follows
```
environments:
    test:
        dataSource:
            dbCreate: update
            url: '${test.dataSource.url}'
```