### PR TITLE
Include autowire configuration for example

### DIFF
--- a/docs/src/docs/asciidoc/advancedGORMFeatures/eventsAutoTimestamping.adoc
+++ b/docs/src/docs/asciidoc/advancedGORMFeatures/eventsAutoTimestamping.adoc
@@ -55,12 +55,18 @@ class Person {
    static constraints = {
       lastUpdatedBy nullable: true
    }
-
+   
+   static mapping = {
+      autowire true
+   }
+   
    def beforeUpdate() {
       lastUpdatedBy = securityService.currentAuthenticatedUsername()
    }
 }
 ----
+
+Notice the usage of `autowire true` above. This is required for the bean `securityService` to be injected.
 
 
 ==== The beforeDelete event


### PR DESCRIPTION
Newer versions of GORM do not autowire beans by default, so explicitly autowire the security service for the `beforeInsert()` example that uses it.