### PR TITLE
Fix #104; Add the serializableProxyMethod to the proxy initializer class

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/proxy/ProxyFactorySupport.groovy
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/proxy/ProxyFactorySupport.groovy
@@ -92,6 +92,7 @@ class ProxyFactorySupport {
                 setIdentifierMethod,
                 componentIdType);       
 }""")
+            initializerClass.addMethod(serializableProxyMethod)
 
             // Add method: Object invoke(Object, Method, Method, Object[])
             CtClass methodType = getClassFromPool(pool, Method.name)


### PR DESCRIPTION
Looks like it was just an oversight to create the method and not add it to the initializer class.