### PR TITLE
Upgrade to Grails 4

### DIFF
--- a/examples/grails3-database-per-tenant/build.gradle
+++ b/examples/grails3-database-per-tenant/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     runtime "org.grails.plugins:scaffolding:3.3.1"
     runtime 'org.grails.plugins:fields:2.1.3'
 
-    testCompile "org.grails:grails-gorm-testing-support:1.1.4"
+    testCompile "org.grails:grails-gorm-testing-support:$testingSupportVersion"
     testCompile "org.grails.plugins:geb:1.0.2"
 
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"

--- a/examples/grails3-hibernate5/build.gradle
+++ b/examples/grails3-hibernate5/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     runtime "org.grails.plugins:scaffolding:3.3.1"
     runtime 'org.grails.plugins:fields:2.1.3'
 
-    testCompile "org.grails:grails-gorm-testing-support:1.1.4"
-    testCompile "org.grails:grails-web-testing-support:1.1.4"
+    testCompile "org.grails:grails-gorm-testing-support:$testingSupportVersion"
+    testCompile "org.grails:grails-web-testing-support:$testingSupportVersion"
     testCompile "org.grails.plugins:geb:1.0.2"
 
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"

--- a/examples/grails3-multiple-datasources/build.gradle
+++ b/examples/grails3-multiple-datasources/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     runtime "org.grails.plugins:scaffolding:3.3.1"
     runtime 'org.grails.plugins:fields:2.1.3'
 
-    testCompile "org.grails:grails-gorm-testing-support:1.1.4"
+    testCompile "org.grails:grails-gorm-testing-support:$testingSupportVersion"
     testCompile "org.grails.plugins:geb:1.0.2"
 
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"

--- a/examples/grails3-partitioned-multi-tenancy/build.gradle
+++ b/examples/grails3-partitioned-multi-tenancy/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     runtime "org.grails.plugins:scaffolding:3.3.1"
     runtime 'org.grails.plugins:fields:2.1.3'
 
-    testCompile "org.grails:grails-gorm-testing-support:1.1.4"
+    testCompile "org.grails:grails-gorm-testing-support:$testingSupportVersion"
     testCompile "org.grails.plugins:geb:1.0.2"
 
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"

--- a/examples/grails3-schema-per-tenant/build.gradle
+++ b/examples/grails3-schema-per-tenant/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     runtime "org.grails.plugins:scaffolding:3.3.1"
     runtime 'org.grails.plugins:fields:2.1.3'
 
-    testCompile "org.grails:grails-gorm-testing-support:1.1.4"
+    testCompile "org.grails:grails-gorm-testing-support:$testingSupportVersion"
     testCompile "org.grails.plugins:geb:1.0.2"
 
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 gormVersion=7.0.0.BUILD-SNAPSHOT
 slf4jVersion=1.7.25
-grailsVersion=3.3.8
+grailsVersion=4.0.0.BUILD-SNAPSHOT
 groovyVersion=2.5.4
 springBootVersion=2.1.0.RELEASE
 springVersion=5.1.2.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ springVersion=5.1.2.RELEASE
 hibernate5Version=5.3.6.Final
 hibernateValidatorVersion=6.0.13.Final
 jaxbVersion=2.3.1
+testingSupportVersion=2.0.0.BUILD-SNAPSHOT

--- a/grails-plugin/build.gradle
+++ b/grails-plugin/build.gradle
@@ -35,7 +35,7 @@ dependencies {
         exclude group:'javax.transaction', module:'jta'
     }
 
-    testCompile "org.grails:grails-gorm-testing-support:1.1.4"
+    testCompile "org.grails:grails-gorm-testing-support:$testingSupportVersion"
     testRuntime "com.h2database:h2:1.4.192"
     testRuntime "org.apache.tomcat:tomcat-jdbc:8.5.0"
     testRuntime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:8.5.0"

--- a/grails-plugin/build.gradle
+++ b/grails-plugin/build.gradle
@@ -20,6 +20,7 @@ dependencies {
         exclude module:'groovy-all'
     }
 
+    compile "org.springframework.boot:spring-boot:$springBootVersion"
     compile "org.springframework:spring-orm:$springVersion"
     compile "org.hibernate:hibernate-core:${hibernate5Version}"
     compile "org.grails:grails-datastore-web:$gormVersion"


### PR DESCRIPTION
This PR includes:
- Update `HibernateSpec` to remove usage of `PropertySourcesLoader` that has been removed in Spring Boot 2.1
- Use `testing-support` version `2.0.0.BUILD-SNAPSHOT`
- Use `grails-core` version `4.0.0.BUILD-SNAPSHOT`
