### PR TITLE
Fix #144 - GORM autotimestamp issue

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/support/ClosureEventTriggeringInterceptor.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/support/ClosureEventTriggeringInterceptor.java
@@ -184,8 +184,12 @@ public class ClosureEventTriggeringInterceptor extends AbstractClosureEventTrigg
         }
     }
 
-    private void synchronizeHibernateState(PreUpdateEvent hibernateEvent, ModificationTrackingEntityAccess entityAccess) {
-        Map<String, Object> modifiedProperties = getModifiedPropertiesWithAutotimestamp(hibernateEvent, entityAccess);
+    private void synchronizeHibernateState(PreUpdateEvent hibernateEvent, ModificationTrackingEntityAccess entityAccess, boolean autoTimestamp) {
+        Map<String, Object> modifiedProperties = entityAccess.getModifiedProperties();
+
+        if (autoTimestamp) {
+            updateModifiedPropertiesWithAutoTimestamp(modifiedProperties, hibernateEvent);
+        }
 
         if (!modifiedProperties.isEmpty()) {
             Object[] state = hibernateEvent.getState();
@@ -194,20 +198,18 @@ public class ClosureEventTriggeringInterceptor extends AbstractClosureEventTrigg
         }
     }
 
-    private Map<String, Object> getModifiedPropertiesWithAutotimestamp(PreUpdateEvent hibernateEvent, ModificationTrackingEntityAccess entityAccess) {
-        Map<String, Object> modifiedProperties = entityAccess.getModifiedProperties();
+    private void updateModifiedPropertiesWithAutoTimestamp(Map<String, Object> modifiedProperties, PreUpdateEvent hibernateEvent) {
 
         EntityMetamodel entityMetamodel = hibernateEvent.getPersister().getEntityMetamodel();
         Integer dateCreatedIdx = entityMetamodel.getPropertyIndexOrNull(AutoTimestampEventListener.DATE_CREATED_PROPERTY);
 
         Object[] oldState = hibernateEvent.getOldState();
         Object[] state = hibernateEvent.getState();
+
         // Only for "dateCreated" property, "lastUpdated" is handled correctly
         if (dateCreatedIdx != null && oldState != null && oldState[dateCreatedIdx] != null && !oldState[dateCreatedIdx].equals(state[dateCreatedIdx])) {
             modifiedProperties.put(AutoTimestampEventListener.DATE_CREATED_PROPERTY, oldState[dateCreatedIdx]);
         }
-
-        return modifiedProperties;
     }
 
     private void synchronizeHibernateState(EntityPersister persister, Object[] state, Map<String, Object> modifiedProperties) {
@@ -246,7 +248,8 @@ public class ClosureEventTriggeringInterceptor extends AbstractClosureEventTrigg
         publishEvent(hibernateEvent, grailsEvent);
         boolean cancelled = grailsEvent.isCancelled();
         if(!cancelled && entityAccess != null) {
-            synchronizeHibernateState(hibernateEvent, entityAccess);
+            boolean autoTimestamp = persistentEntity.getMapping().getMappedForm().isAutoTimestamp();
+            synchronizeHibernateState(hibernateEvent, entityAccess, autoTimestamp);
         }
         return cancelled;
 

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/AutoTimestampSpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/AutoTimestampSpec.groovy
@@ -1,0 +1,85 @@
+package grails.gorm.tests
+
+import grails.gorm.annotation.Entity
+
+class AutoTimestampSpec extends GormDatastoreSpec {
+    @Override
+    List getDomainClasses() {
+        [DateCreatedTestA, DateCreatedTestB]
+    }
+
+    void "autoTimestamp should prevent custom changes to dateCreated and lastUpdated if turned on"() {
+        when: "testing insert ignores custom dateCreated and lastUpdated"
+        def before = new Date() - 5
+        def a = new DateCreatedTestA(name: 'David Estes', lastUpdated: before, dateCreated: before)
+        a.save(flush:true)
+        a.refresh()
+        def lastUpdated = a.lastUpdated
+        def dateCreated = a.dateCreated
+
+        then:
+        lastUpdated > before
+        dateCreated > before
+
+        when: "testing update ignores custom dateCreated and lastUpdated"
+        a.name = "David R. Estes"
+        a.lastUpdated = before - 5
+        a.dateCreated = before - 5
+        a.save(flush:true)
+        a.refresh()
+
+        then:
+        a.lastUpdated > lastUpdated
+        a.dateCreated == dateCreated
+    }
+
+    void "dateCreated and lastUpdated should not be modified by GORM if turned off"() {
+        when: "insert allows custom dateCreated and lastUpdated"
+        def now = new Date()
+        def before = now - 5
+
+        def a = new DateCreatedTestB(name: 'David Estes', lastUpdated: before, dateCreated: before)
+        a.save(flush:true)
+        a.refresh()
+
+        def lastUpdated = a.lastUpdated
+        def dateCreated = a.dateCreated
+
+        then:
+        lastUpdated == before
+        dateCreated == before
+
+        when: "update allows custom dateCreated and lastUpdated"
+        a.name = "David R. Estes"
+        a.lastUpdated = now
+        a.dateCreated = now
+        a.save(flush:true)
+        a.refresh()
+
+        then:
+        a.lastUpdated == now
+        a.dateCreated == now
+    }
+}
+
+@Entity
+class DateCreatedTestA {
+    String name
+    Date dateCreated
+    Date lastUpdated
+
+    static mapping = {
+        autoTimestamp true
+    }
+}
+
+@Entity
+class DateCreatedTestB {
+    String name
+    Date dateCreated
+    Date lastUpdated
+
+    static mapping = {
+        autoTimestamp false
+    }
+}


### PR DESCRIPTION
GORM should not handle dateCreated or lastUpdated fields if autoTimestamp is disabled.

I think this addresses the concern in the previous pull request. If not please let me know and I can make further updates.