### PR TITLE
Add public modifier to proxy related classes to fix IllegalAccessError

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/proxy/HibernateGroovyObjectMethodHandler.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/proxy/HibernateGroovyObjectMethodHandler.java
@@ -9,12 +9,12 @@ import org.hibernate.proxy.LazyInitializer;
  * @author Graeme Rocher
  * @since 6.1.2
  */
-class HibernateGroovyObjectMethodHandler extends EntityProxyMethodHandler {
+public class HibernateGroovyObjectMethodHandler extends EntityProxyMethodHandler {
     private Object target;
     private final Object originalSelf;
     private final LazyInitializer lazyInitializer;
 
-    HibernateGroovyObjectMethodHandler(Class<?> proxyClass, Object originalSelf, LazyInitializer lazyInitializer) {
+    public HibernateGroovyObjectMethodHandler(Class<?> proxyClass, Object originalSelf, LazyInitializer lazyInitializer) {
         super(proxyClass);
         this.originalSelf = originalSelf;
         this.lazyInitializer = lazyInitializer;

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/proxy/ProxyFactorySupport.groovy
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/proxy/ProxyFactorySupport.groovy
@@ -35,6 +35,7 @@ class ProxyFactorySupport {
             // first make the lazy initializer
             String initializerName = "${ProxyFactorySupport.package.name}.GroovyAwareJavassistLazyInitializer"
             CtClass initializerSuperClass = getClassFromPool(pool, BasicLazyInitializer.name)
+            pool.getOrNull(initializerName)?.defrost()
             CtClass initializerClass = pool.makeClass(initializerName, initializerSuperClass)
             initializerClass.addInterface(getClassFromPool(pool, MethodHandler.name))
 
@@ -151,6 +152,7 @@ class ProxyFactorySupport {
             // now make the proxy factory
             String factoryName = "${ProxyFactorySupport.package.name}.GroovyAwareJavassistProxyFactory"
             CtClass factorySuperClass = getClassFromPool(pool, AbstractGroovyAwareJavassistProxyFactory.name)
+            pool.getOrNull(factoryName)?.defrost()
             CtClass factorCls = pool.makeClass(factoryName, factorySuperClass)
 
             CtMethod getProxyMethod = factorySuperClass.getMethods().find { CtMethod m -> m.name == 'getProxy' }


### PR DESCRIPTION
When running a Grails 3.3x application with Gorm 6.1.x and Spring Security REST, in Open Liberty the following exception is raised:
```
org.hibernate.HibernateException: Javassist Enhancement failed: class liberty.demo.Role
    [...]
Caused by: java.lang.IllegalAccessError: tried to access class org.grails.orm.hibernate.proxy.HibernateGroovyObjectMethodHandler from class org.grails.orm.hibernate.proxy.GroovyAwareJavassistLazyInitializer
	at org.grails.orm.hibernate.proxy.GroovyAwareJavassistLazyInitializer.<init>(GroovyAwareJavassistLazyInitializer.java)
```

Adding the `public` modifier to `HibernateGroovyObjectMethodHandler` class and constructor fixes the issue.