### PR TITLE
Embeddable classes can be located under src/main/groovy

### DIFF
--- a/docs/src/docs/asciidoc/domainClasses/gormComposition.adoc
+++ b/docs/src/docs/asciidoc/domainClasses/gormComposition.adoc
@@ -18,4 +18,4 @@ The resulting mapping would looking like this:
 
 image::5.2.2-composition.jpg[]
 
-NOTE: If you define the `Address` class in a separate Groovy file in the `grails-app/domain` directory you will also get an `address` table. If you don't want this to happen use Groovy's ability to define multiple classes per file and include the `Address` class below the `Person` class in the `grails-app/domain/Person.groovy` file
+NOTE: If you define the `Address` class in a separate Groovy file in the `grails-app/domain` directory you will also get an `address` table. If you don't want this to happen use Groovy's ability to define multiple classes per file and include the `Address` class below the `Person` class in the `grails-app/domain/Person.groovy` file. Another option is to define the `Address` class in `src/main/groovy/Address.groovy` and annotate it with `grails.gorm.annotation.Entity`


### PR DESCRIPTION
In a Slack discussion on September 13th I promised to add some info to the docs about embeddable classes can be put under src/main/groovy to make it easy to embed the same class in multiple domain classes. So here it comes.

A mistake I did in a project was to use the wrong `Entity` annotation. I used `javax.persiatnce.Entity` and that resulted in **"No identifier specified for entity my.package.Address"**. It's important to use the correct `grails.gorm.annotation.Entity` annotation. I added the class name to the docs. Is that enough or should we explain that more in depth?