### PR TITLE
Create implicit alias for subquery instead of using alias this_

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
@@ -207,6 +207,10 @@ public class HibernateCriteriaBuilder extends AbstractHibernateCriteriaBuilder {
 
     public static org.hibernate.criterion.DetachedCriteria getHibernateDetachedCriteria(AbstractHibernateQuery query, QueryableCriteria<?> queryableCriteria) {
         String alias = queryableCriteria.getAlias();
+        return getHibernateDetachedCriteria(query, queryableCriteria, alias);
+    }
+
+    public static org.hibernate.criterion.DetachedCriteria getHibernateDetachedCriteria(AbstractHibernateQuery query, QueryableCriteria<?> queryableCriteria, String alias) {
         PersistentEntity persistentEntity = queryableCriteria.getPersistentEntity();
         Class targetClass = persistentEntity.getJavaClass();
         org.hibernate.criterion.DetachedCriteria detachedCriteria;

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/query/HibernateCriterionAdapter.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/query/HibernateCriterionAdapter.java
@@ -37,4 +37,12 @@ public class HibernateCriterionAdapter extends AbstractHibernateCriterionAdapter
     protected DetachedCriteria toHibernateDetachedCriteria(AbstractHibernateQuery hibernateQuery, QueryableCriteria<?> queryableCriteria) {
         return HibernateCriteriaBuilder.getHibernateDetachedCriteria(hibernateQuery, queryableCriteria);
     }
+
+    @Override
+    protected DetachedCriteria toHibernateDetachedCriteria(AbstractHibernateQuery hibernateQuery, QueryableCriteria<?> queryableCriteria, String alias) {
+        if (alias == null) {
+            return toHibernateDetachedCriteria(hibernateQuery, queryableCriteria);
+        }
+        return HibernateCriteriaBuilder.getHibernateDetachedCriteria(hibernateQuery, queryableCriteria, alias);
+    }
 }

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/DetachCriteriaSubquerySpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/DetachCriteriaSubquerySpec.groovy
@@ -43,6 +43,36 @@ class DetachCriteriaSubquerySpec extends GormDatastoreSpec {
         result.size() == 1
     }
 
+    void "test that detached criteria subquery should create implicit alias instead of using this_"() {
+
+        setup:
+        User supVisor = createUser('supervisor@company.com')
+        User user1 = createUser('user1@company.com')
+        User user2 = createUser('user2@company.com')
+
+        Group group1 = createGroup('Group 1', supVisor)
+        Group group2 = createGroup('Group 2', supVisor)
+
+        assignGroup(user1, group1)
+        assignGroup(user1, group2)
+
+        when:
+        String supervisorEmail = 'supervisor@company.com'
+        DetachedCriteria<User> criteria = User.where {
+            def u = User
+            exists(
+                    GroupAssignment.where {
+                        user.id == u.id && group.supervisor.email == supervisorEmail
+                    }.id()
+            )
+        }
+        List<User> result = criteria.list()
+
+        then:
+        noExceptionThrown()
+        result.size() == 1
+    }
+
     private User createUser(String email) {
         User user = new User()
         user.email = email

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/DetachCriteriaSubquerySpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/DetachCriteriaSubquerySpec.groovy
@@ -31,14 +31,16 @@ class DetachCriteriaSubquerySpec extends GormDatastoreSpec {
             def u = User
             exists(
                     GroupAssignment.where {
+                        def ga0 = GroupAssignment
                         user.id == u.id && group.supervisor.email == supervisorEmail
                     }.id()
             )
         }
-        criteria.list()
+        List<User> result = criteria.list()
 
         then:
         noExceptionThrown()
+        result.size() == 1
     }
 
     private User createUser(String email) {

--- a/grails-datastore-gorm-hibernate5/src/test/resources/simplelogger.properties
+++ b/grails-datastore-gorm-hibernate5/src/test/resources/simplelogger.properties
@@ -1,2 +1,3 @@
 #org.slf4j.simpleLogger.defaultLogLevel=debug
-org.slf4j.simpleLogger.log.org.hibernate=trace
+#org.slf4j.simpleLogger.log.org.hibernate=trace
+#org.slf4j.simpleLogger.log.org.hibernate.SQL=debug


### PR DESCRIPTION
- Added method `getHibernateDetachedCriteria(AbstractHibernateQuery query, QueryableCriteria<?> queryableCriteria, String alias)` to accept alias as an argument in `HibernateCriteriaBuilder`.
- Updated `Query.Exists.class` criterionAdaptor to explicitly create and pass the new alias to the detachedCriteria, only if the `subquery.alias` is `null`.
- Added method `protected org.hibernate.criterion.DetachedCriteria toHibernateDetachedCriteria(AbstractHibernateQuery query, QueryableCriteria<?> queryableCriteria, String alias)` to the `AbstractHibernateCriterionAdapter` with default implementation
- Overidde `toHibernateDetachedCriteria(AbstractHibernateQuery query, QueryableCriteria<?> queryableCriteria, String alias)` in `HibernateCriteriaAdaptor` to pass the alias.

Fixes #171 