### PR TITLE
Asciidoc formatting tweak for inline code

### DIFF
--- a/docs/src/docs/asciidoc/persistenceBasics/cascades.adoc
+++ b/docs/src/docs/asciidoc/persistenceBasics/cascades.adoc
@@ -22,7 +22,7 @@ class Flight {
 }
 ----
 
-If I now create an `Airport` and add some `Flight`s to it I can save the `Airport` and have the updates cascaded down to each flight, hence saving the whole object graph:
+If I now create an `Airport` and add some ``Flight``s to it I can save the `Airport` and have the updates cascaded down to each flight, hence saving the whole object graph:
 
 [source,groovy]
 ----


### PR DESCRIPTION
Adding the plural to `Flight`s causes strange Asciidoc rendering. Updated per the [Asciidoc reference](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#source-code)

| Old | New | 
|---|---|
| <img width="375" alt="image" src="https://user-images.githubusercontent.com/64936635/82777286-06d09180-9e91-11ea-82ca-8863df5f413b.png"> | <img width="340" alt="image" src="https://user-images.githubusercontent.com/64936635/82777353-38e1f380-9e91-11ea-8d6f-4aee6793cc51.png"> |
