### PR TITLE
Fix missing images in docs

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -51,8 +51,8 @@ dependencies {
 
 asciidoctor {
     resources {
-        from("${project.projectDir}/src/docs/images")
-        into "${project.projectDir}/images"
+        from("${project.projectDir}/src/docs/asciidoc/images")
+        into "./images"
     }
 
     attributes  'experimental'  : 'true',
@@ -60,7 +60,7 @@ asciidoctor {
                 'icons'         : 'font',
                 'reproducible'  : '',
                 'version'       : project.version,
-                'pluginVersion' : project.version - '.RELEASE', 
+                'pluginVersion' : project.version - '.RELEASE',
                 'sourcedir'     : "${project.projectDir}/src/main/groovy"
 }
 


### PR DESCRIPTION
The error
```
GET http://gorm.grails.org/latest/hibernate/manual/images/5.2.2-composition.jpg 404 (Not Found)
```

The `images` directory was not being copied. See https://asciidoctor.github.io/asciidoctor-gradle-plugin/development-3.x/user-guide/#_processing_auxiliary_files