### PR TITLE
grails/grails-data-mapping#1368 - verify that autowiring interface…

### DIFF
--- a/examples/test-data-service/grails-app/init/example/Application.groovy
+++ b/examples/test-data-service/grails-app/init/example/Application.groovy
@@ -4,8 +4,10 @@ import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
 
 import groovy.transform.CompileStatic
+import org.springframework.context.annotation.ComponentScan
 
 @CompileStatic
+@ComponentScan
 class Application extends GrailsAutoConfiguration {
     static void main(String[] args) {
         GrailsApp.run(Application, args)

--- a/examples/test-data-service/grails-app/init/example/TestConfig.groovy
+++ b/examples/test-data-service/grails-app/init/example/TestConfig.groovy
@@ -1,0 +1,12 @@
+package example
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class TestConfig {
+
+    @Autowired
+    BookService bookService
+
+}

--- a/examples/test-data-service/src/main/groovy/example/TestBeanPostProcessor.groovy
+++ b/examples/test-data-service/src/main/groovy/example/TestBeanPostProcessor.groovy
@@ -1,0 +1,13 @@
+package example
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.config.BeanPostProcessor
+import org.springframework.stereotype.Component
+
+@Component
+class TestBeanPostProcessor implements BeanPostProcessor {
+
+    @Autowired
+    BookService bookService
+
+}


### PR DESCRIPTION
…typed data services works into `Configuration` beans as well as `BeanPostProcessor` beans

@puneetbehl looks like the tests pass with gdm-7.0.6 as well (without devtools) because spring already defensively returns null but logs the `ArrayIndexOutOfBoundsException` at `INFO` level here: https://github.com/spring-projects/spring-framework/blob/v5.1.17.RELEASE/spring-beans/src/main/java/org/springframework/beans/factory/support/FactoryBeanRegistrySupport.java#L69-L71

as discussed in grails/grails-data-mapping#1371, to be able to fully reproduce the `NoSuchBeanDefinitionException` we would need to have a way to enable/simulate the devtools restart classloader for integration tests.

thank you!