### PR TITLE
Fix composite ID not visible to JPA

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -1828,6 +1828,7 @@ public class GrailsDomainBinder implements MetadataContributor {
         Component id = new Component(metadataBuildingContext, root);
         id.setNullValue("undefined");
         root.setIdentifier(id);
+        root.setIdentifierMapper(id);
         root.setEmbeddedIdentifier(true);
         id.setComponentClassName(domainClass.getName());
         id.setKey(true);

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdCriteria.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdCriteria.groovy
@@ -1,0 +1,95 @@
+package grails.gorm.tests.compositeid
+
+import grails.gorm.annotation.Entity
+import grails.gorm.hibernate.mapping.MappingBuilder
+import grails.gorm.transactions.Rollback
+import org.grails.orm.hibernate.HibernateDatastore
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+@Rollback
+class CompositeIdCriteria extends Specification {
+
+  @Shared
+  @AutoCleanup
+  HibernateDatastore datastore = new HibernateDatastore(CompositeIdToMany, CompositeIdSimple, Author, Book)
+
+  @Issue("https://github.com/grails/gorm-hibernate5/issues/234")
+  def "test that composite to-many properties can be queried using JPA"() {
+    Author _author = new Author(name:"Author").save()
+    Book _book = new Book(title:"Book").save()
+    CompositeIdToMany compositeIdToMany = new CompositeIdToMany(author:_author, book:_book).save(failOnError:true, flush:true)
+
+    def criteriaBuilder = datastore.sessionFactory.criteriaBuilder
+    def criteriaQuery = criteriaBuilder.createQuery()
+    def root = criteriaQuery.from(CompositeIdToMany)
+    criteriaQuery.select(root)
+    criteriaQuery.where(criteriaBuilder.equal(root.get("author"), _author))
+    def query = datastore.sessionFactory.currentSession.createQuery(criteriaQuery)
+
+    expect:
+    query.list() == [compositeIdToMany]
+  }
+
+  def "test that composite can be queried using JPA"() {
+    CompositeIdSimple compositeIdSimple = new CompositeIdSimple(name:"name", age:2l).save(failOnError:true, flush:true)
+
+    def criteriaBuilder = datastore.sessionFactory.criteriaBuilder
+    def criteriaQuery = criteriaBuilder.createQuery()
+    def root = criteriaQuery.from(CompositeIdSimple)
+    criteriaQuery.select(root)
+    criteriaQuery.where(criteriaBuilder.equal(root.get("name"), "name"))
+    def query = datastore.sessionFactory.currentSession.createQuery(criteriaQuery)
+
+    expect:
+    query.list() == [compositeIdSimple]
+  }
+
+  @Issue("https://github.com/grails/grails-data-mapping/issues/1351")
+  def "test that composite to-many can be used in criteria"() {
+    Author _author = new Author(name:"Author").save()
+    Book _book = new Book(title:"Book").save()
+    CompositeIdToMany compositeIdToMany = new CompositeIdToMany(author:_author, book:_book).save(failOnError:true, flush:true)
+
+    expect:
+    CompositeIdToMany.createCriteria().list {
+      author {
+        eq('id', _author.id)
+      }
+    } == [compositeIdToMany]
+  }
+}
+
+@Entity
+class Author {
+  String name
+}
+
+@Entity
+class Book {
+  String title
+}
+
+@Entity
+class CompositeIdToMany implements Serializable {
+  Author author
+  Book book
+
+  static mapping = MappingBuilder.define {
+    composite("author", "book")
+  }
+}
+
+@Entity
+class CompositeIdSimple implements Serializable {
+  String name
+  Long age
+
+  static mapping = MappingBuilder.define {
+    composite("name", "age")
+  }
+}
+
+

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdWithDeepOneToManyMappingSpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/compositeid/CompositeIdWithDeepOneToManyMappingSpec.groovy
@@ -43,7 +43,7 @@ class Child implements Serializable {
     static belongsTo= [parent: Parent]
 
     static mapping = MappingBuilder.define {
-        id(composite: ['parent', 'name'])
+        composite('parent', 'name')
     }
 }
 
@@ -56,7 +56,7 @@ class Parent implements Serializable {
     static hasMany= [children: Child]
 
     static mapping= MappingBuilder.define {
-        id(composite: ['grandParent', 'name'])
+        composite('grandParent', 'name')
     }
 }
 
@@ -69,6 +69,6 @@ class GrandParent implements Serializable {
     static hasMany= [parents: Parent]
 
     static mapping= MappingBuilder.define {
-        id(composite: ['name', 'luckyNumber'])
+        composite('name', 'luckyNumber')
     }
 }

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/org/grails/orm/hibernate/compiler/HibernateEntityTransformationSpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/org/grails/orm/hibernate/compiler/HibernateEntityTransformationSpec.groovy
@@ -155,17 +155,3 @@ class MyEntity {
         myEntity.name == 'changed'
     }
 }
-@grails.gorm.hibernate.annotation.ManagedEntity
-class MyTest {
-    String name
-    String lastName
-    int age
-
-    String getLastName() {
-        return this.lastName
-    }
-
-    void setLastName(String name) {
-        this.lastName = name
-    }
-}


### PR DESCRIPTION
I am not sure if this fix is correct.

The hibernate documentation [1] says that there are the following ways to define a composite identity:

- @EmbeddedId
- @IdClass
- Composite identifiers with associations => Use @id multiple times

I am not sure what the binding by `bindCompositeId` corresponds to.

I just know that in the 3rd case hibernate does set the `identifierMapper`. I am not sure if there is valid in the other cases.

[1]: https://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#identifiers-composite

Fixes #234 