### PR TITLE
Disable Travis Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+branches:
+  only:
+    - 7.0.x
+    - 6.1.x
 jdk:
 - openjdk14
 - openjdk11


### PR DESCRIPTION
Only execute Travis build for 6.1.x and 7.0.x branches.