### PR TITLE
Set HibernateDatastore as the Primary Datastore

### DIFF
--- a/grails-plugin/src/main/groovy/grails/orm/bootstrap/HibernateDatastoreSpringInitializer.groovy
+++ b/grails-plugin/src/main/groovy/grails/orm/bootstrap/HibernateDatastoreSpringInitializer.groovy
@@ -151,7 +151,9 @@ class HibernateDatastoreSpringInitializer extends AbstractDatastoreInitializer {
                 bean.autowire = true
                 dataSourceConnectionSourceFactory = ref('dataSourceConnectionSourceFactory')
             }
-            hibernateDatastore(HibernateDatastore, config, hibernateConnectionSourceFactory, eventPublisher)
+            hibernateDatastore(HibernateDatastore, config, hibernateConnectionSourceFactory, eventPublisher) { bean->
+                bean.primary = true
+            }
             sessionFactory(hibernateDatastore:'getSessionFactory')
             transactionManager(hibernateDatastore:"getTransactionManager")
             autoTimestampEventListener(hibernateDatastore:"getAutoTimestampEventListener")


### PR DESCRIPTION
When multiple Datastore beans are available then HibernateDatastore would be preferred as the primary datastore.