### PR TITLE
Second level cache not working for inherited domains

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -1517,7 +1517,7 @@ public class GrailsDomainBinder implements MetadataContributor {
             subClass.setDynamicInsert(true);
         }
 
-        subClass.setCached(parent.isCached())
+        subClass.setCached(parent.isCached());
 
         subClass.setAbstract(sub.isAbstract());
         subClass.setEntityName(fullName);

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -1516,7 +1516,9 @@ public class GrailsDomainBinder implements MetadataContributor {
         if (m.getDynamicInsert()) {
             subClass.setDynamicInsert(true);
         }
-        
+
+        subClass.setCached(parent.isCached())
+
         subClass.setAbstract(sub.isAbstract());
         subClass.setEntityName(fullName);
         subClass.setJpaEntityName(unqualify(fullName));


### PR DESCRIPTION
Fix for issue with cached
[Second level cache not working for inherited domains](https://github.com/grails/grails-data-mapping/issues/1594)

have no idea how I can test it.

But by MetamodelImpl initialize method logic I think it right solution to copy cache settings from parent to child 

In this case code in org.hibernate.persister.entity.AbstractEntityPersister:590 working correct 