### PR TITLE
Fixes #598 without breaking #171

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriterionAdapter.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriterionAdapter.java
@@ -179,7 +179,12 @@ public abstract class AbstractHibernateCriterionAdapter {
             @Override
             public Criterion toHibernateCriterion(AbstractHibernateQuery hibernateQuery, Query.Criterion criterion, String alias) {
                 DetachedAssociationCriteria<?> existing = (DetachedAssociationCriteria<?>) criterion;
-                alias = hibernateQuery.handleAssociationQuery(existing.getAssociation(), existing.getCriteria());
+                if(existing.getAlias() == null) {
+                    alias = hibernateQuery.handleAssociationQuery(existing.getAssociation(), existing.getCriteria());
+                }
+                else{
+                    alias = hibernateQuery.handleAssociationQuery(existing.getAssociation(), existing.getCriteria(), existing.getAlias());
+                }
                 Association association = existing.getAssociation();
                 hibernateQuery.associationStack.add(association);
                 Junction conjunction = Restrictions.conjunction();

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/DetachedCriteriaProjectionAliasSpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/DetachedCriteriaProjectionAliasSpec.groovy
@@ -1,0 +1,69 @@
+package grails.gorm.tests
+
+import grails.gorm.DetachedCriteria
+import grails.gorm.transactions.Rollback
+import grails.gorm.transactions.Transactional
+import org.grails.orm.hibernate.HibernateDatastore
+import org.springframework.transaction.PlatformTransactionManager
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+
+class DetachedCriteriaProjectionAliasSpec extends Specification {
+
+    @Shared @AutoCleanup HibernateDatastore datastore = new HibernateDatastore(Entity1, Entity2, DetachedEntity)
+    @Shared PlatformTransactionManager transactionManager = datastore.getTransactionManager()
+
+    @Transactional
+    def setup() {
+        DetachedEntity.findAll().each { it.delete() }
+        Entity1.findAll().each { it.delete(flush: true) }
+        Entity2.findAll().each { it.delete(flush: true) }
+        final entity1 = new Entity1(id: 1, field1: 'E1').save()
+        final entity2 = new Entity2(id: 2, field: 'E2', parent: entity1).save()
+        entity1.addToChildren(entity2)
+        new DetachedEntity(id: 1, entityId: entity1.id, field: 'DE1').save()
+        new DetachedEntity(id: 2, entityId: entity1.id, field: 'DE2').save()
+    }
+
+    @Rollback
+    @Issue('https://github.com/grails/gorm-hibernate5/issues/598')
+    def 'test projection in detached criteria subquery with aliased join and restriction referencing join'() {
+        setup:
+        final detachedCriteria = new DetachedCriteria(Entity1).build {
+            createAlias("children", "e2")
+            projections{
+                property("id")
+            }
+            eq("e2.field", "E2")
+        }
+        when:
+        def res = DetachedEntity.withCriteria {
+            "in"("entityId", detachedCriteria)
+        }
+        then:
+        res.entityId.first() == 1L
+    }
+
+
+    @Rollback
+    @Issue('https://github.com/grails/gorm-hibernate5/issues/598')
+    def 'test aliased projection in detached criteria subquery'() {
+        setup:
+        final detachedCriteria = new DetachedCriteria(Entity2).build {
+            createAlias("parent", "e1")
+            projections{
+                property("e1.id")
+            }
+            eq("field", "E2")
+        }
+        when:
+        def res = DetachedEntity.withCriteria {
+            "in"("entityId", detachedCriteria)
+        }
+        then:
+        res.entityId.first() == 2L
+    }
+}

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/DetachedCriteriaProjectionSpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/DetachedCriteriaProjectionSpec.groovy
@@ -90,7 +90,7 @@ public class Entity1 {
 }
 @Entity
 class Entity2 {
-    static belongsTo = { parent: Entity1 }
+    static belongsTo = [parent: Entity1]
     String field
 }
 @Entity


### PR DESCRIPTION
The issue #171 fixed an problem when converting a DetachedCriteria (using where queries) but it broke DetachedCriterias (not using where queries) when the alias is specified by using `createAlias` as shown in the demo included in #598.

Example:
```groovy
Publisher.createCriteria().list {
            'in'("pubIdentifier", new DetachedCriteria<Isbn>(Isbn).build {
                createAlias("book", "b")
                projections {
                    property("publisher")
                }
                'eq'("b.author", a)
            })
}
```
For domains:
```groovy
class Author {
    static hasMany = [books: Book]
    String name
}

class Book {
    String title
    static belongsTo = [author: Author]
    static hasMany = [isbn: Isbn]
}

class Isbn {
    String pubGroup
    String publisher
    String title
    String checkDigit
    static belongsTo = [book: Book]
}

class Publisher {
    String name
    String pubIdentifier
}
```

The proposed commit allows to use the `createAlias` inside the `DetachedCriteria` as it worked before the changes for #171 without breaking those changes.  