### PR TITLE
Fix getTotalCount() with Hibernate for sorting parameters

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/query/PagedResultList.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/query/PagedResultList.java
@@ -58,7 +58,7 @@ public class PagedResultList extends grails.gorm.PagedResultList {
         if (totalCount == Integer.MIN_VALUE) {
             totalCount = hibernateTemplate.execute(new GrailsHibernateTemplate.HibernateCallback<Integer>() {
                 public Integer doInHibernate(Session session) throws HibernateException, SQLException {
-                    final CriteriaQuery finalQuery = criteriaQuery.select(criteriaBuilder.count(queryRoot)).distinct(true);
+                    final CriteriaQuery finalQuery = criteriaQuery.select(criteriaBuilder.count(queryRoot)).distinct(true).orderBy();
                     final Query query = session.createQuery(finalQuery);
                     hibernateTemplate.applySettings(query);
                     return ((Number)query.uniqueResult()).intValue();


### PR DESCRIPTION
Don't have sorting in the generated query. Otherwise, depending on the database and its strictness configuration, the query might fail.

Fixes #297.

About the `distinct(true)` I am not sure. At least for simple queries it would not be necessary. I have kept it because maybe I am missing corner cases.

This change will only be covered by tests once https://github.com/grails/grails-data-mapping/pull/1758 is merged and a new version of `grails-datastore-gorm-tck` including it used.