### PR TITLE
chore(build): Migrate to Develocity build cache connector

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,19 +13,17 @@ gradleEnterprise {
             taskInputFiles = true
         }
     }
+
 }
 
 buildCache {
     local { enabled = System.getenv('CI') != 'true' }
-    remote(HttpBuildCache) {
-        push = System.getenv('CI') == 'true'
+    remote(gradleEnterprise.buildCache) {
+        def isAuthenticated = System.getenv('GRADLE_ENTERPRISE_ACCESS_KEY')
+        push = System.getenv('CI') == 'true' && isAuthenticated
         enabled = true
-        url = 'https://ge.grails.org/cache/'
-        credentials {
-            username = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER')
-            password = System.getenv('GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY')
-        }
-    }}
+    }
+}
 
 
 // Core


### PR DESCRIPTION
To simplify cache management with  the [Develocity cache connector](https://docs.gradle.com/enterprise/gradle-plugin/#using_the_develocity_connector)