### PR TITLE
fix: create foreign key constraint when `tablePerHierarchy=false` (7.3.x)

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -1615,6 +1615,7 @@ public class GrailsDomainBinder implements MetadataContributor {
         bindSimpleValue(identifier.getType().getName(), key, false, columnName, mappings);
 
         joinedSubclass.createPrimaryKey();
+        joinedSubclass.createForeignKey();
 
         // properties
         createClassProperties(sub, joinedSubclass, mappings, sessionFactoryBeanName);


### PR DESCRIPTION
- https://github.com/grails/grails-data-mapping/issues/1076