### PR TITLE
Update validator version to match spring-boot-starter-validation 3.3.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ groovyVersion=4.0.23
 # Tests are built for 1.4.200, so stick with older version
 h2Version=1.4.200
 hibernate5Version=5.6.15.Final
-hibernateValidatorVersion=7.0.5.Final
+hibernateValidatorVersion=8.0.1.Final
 hibernateGroovyProxy=1.1
 jakartaValidationVersion=3.0.2
 jakartaPersistenceVersion=3.1.0


### PR DESCRIPTION
8.0.1.Final is already automatically resolved by spring-boot-starter-validation

```
+--- org.springframework.boot:spring-boot-starter-validation -> 3.3.4
|    +--- org.springframework.boot:spring-boot-starter:3.3.4 (*)
|    +--- org.apache.tomcat.embed:tomcat-embed-el:10.1.30
|    \--- org.hibernate.validator:hibernate-validator:8.0.1.Final (*)
```