### PR TITLE
Exclude hibernate-ehcache

### DIFF
--- a/docs/src/docs/asciidoc/gettingStarted.adoc
+++ b/docs/src/docs/asciidoc/gettingStarted.adoc
@@ -4,7 +4,9 @@ To use GORM {pluginVersion} for Hibernate in Grails 3 you can specify the follow
 ----
 dependencies {
     compile "org.grails.plugins:hibernate5:{pluginVersion}"
-    compile "org.hibernate:hibernate-ehcache"
+    compile "org.hibernate:hibernate-ehcache", {
+        exclude group:'org.hibernate', module:'hibernate-core'
+    }
 }
 ----
 

--- a/docs/src/docs/asciidoc/gettingStarted.adoc
+++ b/docs/src/docs/asciidoc/gettingStarted.adoc
@@ -4,9 +4,7 @@ To use GORM {pluginVersion} for Hibernate in Grails 3 you can specify the follow
 ----
 dependencies {
     compile "org.grails.plugins:hibernate5:{pluginVersion}"
-    compile "org.hibernate:hibernate-ehcache", {
-        exclude group:'org.hibernate', module:'hibernate-core'
-    }
+    compile "org.hibernate:hibernate-ehcache"
 }
 ----
 

--- a/docs/src/docs/asciidoc/gettingStarted/springBoot.adoc
+++ b/docs/src/docs/asciidoc/gettingStarted/springBoot.adoc
@@ -1,65 +1,49 @@
-To use GORM for Hibernate in Spring Boot add the necessary dependencies to your Boot application:
+To use GORM for Hibernate in Spring Boot, add the necessary dependency to your Boot application:
 
 [source,groovy,subs="attributes"]
+.build.gradle
 ----
-compile("org.grails:gorm-hibernate5-spring-boot:{version}")
-compile "org.hibernate:hibernate-core-jakarta"
-compile "org.hibernate:hibernate-ehcache", {
-    exclude group:'org.hibernate', module:'hibernate-core'
-}
-runtime "com.h2database:h2:1.4.192"
-// for MySQL
-// runtime "mysql:mysql-connector-java"
-
-// for connection pooling
-runtime "org.apache.tomcat:tomcat-jdbc:8.5.0"
-runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:8.5.0"
+implementation 'org.grails:gorm-hibernate5-spring-boot:{version}'
 ----
 
-Then ensure you have configured a https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html[datasource and Hibernate as per the Spring Boot guide]. For example in the case of MySQL:
+Then ensure you have configured a https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.datasource[datasource and Hibernate as per the Spring Boot guide]. For example in the case of MySQL:
 
 [source,yaml]
+.application.yml
 ----
-hibernate:
-    hbm2ddl:
-        auto: update
-    dialect: org.hibernate.dialect.MySQL5InnoDBDialect
-spring:
-    datasource:
-        driverClassName: com.mysql.jdbc.Driver
-        url:   jdbc:mysql://127.0.0.1:3306/gorm
-        username: root
-        password: ""
+hibernate.hbm2ddl.auto: update
+spring.datasource.url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
 ----
 
-TIP: If if you prefer to use the Grails way of configuring the `DataSource` (with `dataSource.url` etc.) then you can add `@EnableAutoConfiguration(exclude = DataSourceAutoConfiguration)` to your `Application` class, which will allow GORM to take over configuring the data source.
-
-Ensure your Boot `Application` class is annotated with `ComponentScan`, for example:
+TIP: If you prefer to use the Grails way of configuring the `DataSource` (with `dataSource.url` etc.), these will
+work as well.
 
 [source,groovy]
+.Application.groovy
 ----
+import groovy.transform.CompileStatic
 import org.springframework.boot.SpringApplication
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.context.annotation.*
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
-@Configuration
-@EnableAutoConfiguration
-@ComponentScan
+@CompileStatic
+@SpringBootApplication(exclude = HibernateJpaAutoConfiguration)
 class Application {
     static void main(String[] args) {
-        SpringApplication.run Application, args
+        SpringApplication.run(Application, args)
     }
 }
 ----
 
-NOTE: Using `ComponentScan` without a value results in Boot scanning for classes in the same package or any package nested within the `Application` class package.
-If your GORM entities are in a different package specify the package name as the value of the `ComponentScan` annotation.
+NOTE: You need to exclude the `HibernateJpaAutoconfiguration` as we are using GORM. Using `SpringBootApplication` without a `basePackages` attribute results in Boot scanning for classes in the same package or any package nested within the `Application` class package.
+If your GORM entities are in a different package, specify the package name as the value of the `basePackages` attribute on the `@SpringBootApplication` annotation.
 
 Finally create your GORM entities and ensure they are annotated with `grails.persistence.Entity`:
 
 [source,groovy]
+.Person.groovy
 ----
-import grails.persistence.*
+import grails.persistence.Entity
 
 @Entity
 class Person {
@@ -71,6 +55,7 @@ class Person {
 Note that Spring Boot does not include any kind of OpenSessionInView interceptor so if you try and invoke GORM methods in a Spring `@Controller` you may encounter a session not found error. To eliminate this problem make sure your `@Controller` methods are annotated with `@Transactional`. For example:
 
 [source,groovy]
+.PersonController.groovy
 ----
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.RequestMapping
@@ -93,8 +78,9 @@ class PersonController {
 In addition, if you wish to return a GORM instance from a Spring `@Controller`, it should be noted that Spring uses Jackson for JSON marshalling, and Jackson will attempt to marshal the entire object to JSON, which can present an issue since GORM adds additional persistence related properties to your domain instance. To resolve this issue you should use `@JsonIgnoreProperties` on your GORM entity class to ignore any properties added by GORM:
 
 [source,groovy]
+.Person.groovy
 ----
-import grails.persistence.*
+import grails.persistence.Entity
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @Entity

--- a/docs/src/docs/asciidoc/gettingStarted/springBoot.adoc
+++ b/docs/src/docs/asciidoc/gettingStarted/springBoot.adoc
@@ -4,7 +4,9 @@ To use GORM for Hibernate in Spring Boot add the necessary dependencies to your 
 ----
 compile("org.grails:gorm-hibernate5-spring-boot:{version}")
 compile "org.hibernate:hibernate-core-jakarta"
-compile "org.hibernate:hibernate-ehcache"
+compile "org.hibernate:hibernate-ehcache", {
+    exclude group:'org.hibernate', module:'hibernate-core'
+}
 runtime "com.h2database:h2:1.4.192"
 // for MySQL
 // runtime "mysql:mysql-connector-java"

--- a/examples/grails-hibernate/build.gradle
+++ b/examples/grails-hibernate/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     runtimeOnly 'org.grails:grails-plugin-services'
     runtimeOnly 'org.grails:grails-plugin-url-mappings'
     runtimeOnly 'org.grails.plugins:fields'
+    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion"
     runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'

--- a/examples/grails-hibernate/build.gradle
+++ b/examples/grails-hibernate/build.gradle
@@ -30,6 +30,9 @@ dependencies {
         // exclude javax variant of hibernate-core 5.6
         exclude group: 'org.hibernate', module: 'hibernate-core'
     }
+    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
     runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'

--- a/examples/grails-hibernate/build.gradle
+++ b/examples/grails-hibernate/build.gradle
@@ -26,7 +26,10 @@ dependencies {
     runtimeOnly 'org.grails:grails-plugin-services'
     runtimeOnly 'org.grails:grails-plugin-url-mappings'
     runtimeOnly 'org.grails.plugins:fields'
-    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion"
+    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core 5.6
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
     runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'

--- a/examples/spring-boot-hibernate/src/main/resources/application.yml
+++ b/examples/spring-boot-hibernate/src/main/resources/application.yml
@@ -1,10 +1,2 @@
-hibernate:
-  cache:
-    queries: false
-    use_second_level_cache: false
-    use_query_cache: false
-dataSource:
-  pooled: true
-  driverClassName: org.h2.Driver
-  dbCreate: create-drop
-  url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+hibernate.hbm2ddl.auto: create-drop
+spring.dataSource.url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@ grailsGradlePluginVersion=7.0.0-M2
 grailsVersion=7.0.0-M1
 groovyVersion=4.0.24
 hibernateVersion=5.6.15.Final
-jbossTransactionApiVersion=2.0.0.Final
 yakworksHibernateGroovyProxyVersion=1.1
 micronautPlatformVersion=4.6.3
 picocliVersion=4.7.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ grailsGradlePluginVersion=7.0.0-M2
 grailsVersion=7.0.0-M1
 groovyVersion=4.0.24
 hibernateVersion=5.6.15.Final
+jbossTransactionApiVersion=2.0.0.Final
 yakworksHibernateGroovyProxyVersion=1.1
 micronautPlatformVersion=4.6.3
 picocliVersion=4.7.6

--- a/grails-datastore-gorm-hibernate/build.gradle
+++ b/grails-datastore-gorm-hibernate/build.gradle
@@ -36,7 +36,10 @@ dependencies {
 
     testImplementation "org.apache.tomcat:tomcat-jdbc"
 
-    testRuntimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion"
+    testRuntimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core 5.6
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
     testRuntimeOnly "org.slf4j:slf4j-simple"
     testRuntimeOnly "org.slf4j:jcl-over-slf4j"
     testRuntimeOnly "org.springframework:spring-aop"

--- a/grails-datastore-gorm-hibernate/build.gradle
+++ b/grails-datastore-gorm-hibernate/build.gradle
@@ -40,6 +40,9 @@ dependencies {
         // exclude javax variant of hibernate-core 5.6
         exclude group: 'org.hibernate', module: 'hibernate-core'
     }
+    testRuntimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
     testRuntimeOnly "org.slf4j:slf4j-simple"
     testRuntimeOnly "org.slf4j:jcl-over-slf4j"
     testRuntimeOnly "org.springframework:spring-aop"

--- a/grails-datastore-gorm-hibernate/build.gradle
+++ b/grails-datastore-gorm-hibernate/build.gradle
@@ -42,7 +42,9 @@ dependencies {
     }
     testImplementation "com.h2database:h2"
 
-    testImplementation "org.hibernate:hibernate-ehcache:$hibernateVersion"
+    testImplementation "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        exclude group:'org.hibernate', module:'hibernate-core'
+    }
 
     // groovy proxy fixes bytebuddy to be a bit smarter when it comes to groovy metaClass
     testImplementation "org.yakworks:hibernate-groovy-proxy:$yakworksHibernateGroovyProxyVersion", {

--- a/grails-datastore-gorm-hibernate/build.gradle
+++ b/grails-datastore-gorm-hibernate/build.gradle
@@ -21,19 +21,6 @@ dependencies {
         exclude group:'org.slf4j', module:'slf4j-api'
     }
 
-    compileOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
-        exclude group:'commons-collections', module:'commons-collections'
-        exclude group:'commons-logging', module:'commons-logging'
-        exclude group:'com.h2database', module:'h2'
-        exclude group:'net.sf.ehcache', module:'ehcache'
-        exclude group:'net.sf.ehcache', module:'ehcache-core'
-        exclude group:'org.hibernate', module:'hibernate-core'
-        exclude group:'org.slf4j', module:'jcl-over-slf4j'
-        exclude group:'org.slf4j', module:'slf4j-api'
-        exclude group:'org.slf4j', module:'slf4j-log4j12'
-        exclude group:'xml-apis', module:'xml-apis'
-    }
-
     testImplementation "org.apache.groovy:groovy-test-junit5"
     testImplementation "org.apache.groovy:groovy-sql"
     testImplementation "org.apache.groovy:groovy-json"
@@ -42,22 +29,17 @@ dependencies {
     }
     testImplementation "com.h2database:h2"
 
-    testImplementation "org.hibernate:hibernate-ehcache:$hibernateVersion", {
-        exclude group:'org.hibernate', module:'hibernate-core'
-    }
-
     // groovy proxy fixes bytebuddy to be a bit smarter when it comes to groovy metaClass
     testImplementation "org.yakworks:hibernate-groovy-proxy:$yakworksHibernateGroovyProxyVersion", {
         exclude group: "org.codehaus.groovy", module: "groovy"
     }
 
     testImplementation "org.apache.tomcat:tomcat-jdbc"
-    testRuntimeOnly "org.springframework:spring-aop"
 
+    testRuntimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion"
     testRuntimeOnly "org.slf4j:slf4j-simple"
     testRuntimeOnly "org.slf4j:jcl-over-slf4j"
-    // The groovydoc task needs the Hibernate 4.x jars in the classpath
-    documentation "org.hibernate:hibernate-core-jakarta:${hibernateVersion}"
+    testRuntimeOnly "org.springframework:spring-aop"
 }
 
 test {

--- a/grails-plugin/build.gradle
+++ b/grails-plugin/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     api "org.hibernate:hibernate-ehcache:$hibernateVersion", {
         exclude group:'org.hibernate', module:'hibernate-core'
     }
+    // required for org.hibernate:hibernate-ehcache to work with org.hibernate:hibernate-core-jakarta
+    api "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        exclude group:"jakarta.enterprise", module:"jakarta.enterprise.cdi-api"
+    }
+
     api "org.grails:grails-datastore-web"
     api "org.grails:grails-datastore-gorm-support"
     api project(":grails-datastore-gorm-hibernate5"), {

--- a/grails-plugin/build.gradle
+++ b/grails-plugin/build.gradle
@@ -25,14 +25,6 @@ dependencies {
     api "org.springframework.boot:spring-boot"
     api "org.springframework:spring-orm"
     api "org.hibernate:hibernate-core-jakarta:$hibernateVersion"
-    api "org.hibernate:hibernate-ehcache:$hibernateVersion", {
-        exclude group:'org.hibernate', module:'hibernate-core'
-    }
-    // required for org.hibernate:hibernate-ehcache to work with org.hibernate:hibernate-core-jakarta
-    api "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
-        exclude group:"jakarta.enterprise", module:"jakarta.enterprise.cdi-api"
-    }
-
     api "org.grails:grails-datastore-web"
     api "org.grails:grails-datastore-gorm-support"
     api project(":grails-datastore-gorm-hibernate5"), {
@@ -45,12 +37,15 @@ dependencies {
         exclude group:'org.grails', module:'grails-core'
         exclude group:'javax.transaction', module:'jta'
     }
-    testRuntimeOnly "org.yaml:snakeyaml"
+
     testImplementation "org.grails:grails-gorm-testing-support"
+
     testRuntimeOnly "com.h2database:h2"
     testRuntimeOnly "org.apache.tomcat:tomcat-jdbc"
+    testRuntimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion"
     testRuntimeOnly "org.springframework:spring-aop"
     testRuntimeOnly "org.springframework:spring-expression"
+    testRuntimeOnly "org.yaml:snakeyaml"
 }
 
 groovydoc.classpath += configurations.documentation

--- a/grails-plugin/build.gradle
+++ b/grails-plugin/build.gradle
@@ -25,7 +25,9 @@ dependencies {
     api "org.springframework.boot:spring-boot"
     api "org.springframework:spring-orm"
     api "org.hibernate:hibernate-core-jakarta:$hibernateVersion"
-    api "org.hibernate:hibernate-ehcache:$hibernateVersion"
+    api "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        exclude group:'org.hibernate', module:'hibernate-core'
+    }
     api "org.grails:grails-datastore-web"
     api "org.grails:grails-datastore-gorm-support"
     api project(":grails-datastore-gorm-hibernate5"), {

--- a/grails-plugin/build.gradle
+++ b/grails-plugin/build.gradle
@@ -42,7 +42,10 @@ dependencies {
 
     testRuntimeOnly "com.h2database:h2"
     testRuntimeOnly "org.apache.tomcat:tomcat-jdbc"
-    testRuntimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion"
+    testRuntimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core 5.6
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
     testRuntimeOnly "org.springframework:spring-aop"
     testRuntimeOnly "org.springframework:spring-expression"
     testRuntimeOnly "org.yaml:snakeyaml"

--- a/grails-plugin/build.gradle
+++ b/grails-plugin/build.gradle
@@ -46,7 +46,7 @@ dependencies {
         // exclude javax variant of hibernate-core 5.6
         exclude group: 'org.hibernate', module: 'hibernate-core'
     }
-    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+    testRuntimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
         // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
     }
     testRuntimeOnly "org.springframework:spring-aop"

--- a/grails-plugin/build.gradle
+++ b/grails-plugin/build.gradle
@@ -46,6 +46,9 @@ dependencies {
         // exclude javax variant of hibernate-core 5.6
         exclude group: 'org.hibernate', module: 'hibernate-core'
     }
+    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
     testRuntimeOnly "org.springframework:spring-aop"
     testRuntimeOnly "org.springframework:spring-expression"
     testRuntimeOnly "org.yaml:snakeyaml"


### PR DESCRIPTION
resolves `hibernate-core` and `hibernate-core-jakarta` being on the classpath

https://github.com/grails/gorm-hibernate5/issues/951