### PR TITLE
fix grails/gorm-hibernate5#973 for grails-7 (9.0.x)

### DIFF
--- a/grails-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommand.groovy
+++ b/grails-database-migration/src/main/groovy/org/grails/plugins/databasemigration/command/ApplicationContextDatabaseMigrationCommand.groovy
@@ -35,7 +35,6 @@ import org.hibernate.engine.jdbc.spi.JdbcServices
 import org.hibernate.engine.spi.SessionFactoryImplementor
 import org.springframework.context.ConfigurableApplicationContext
 
-import static org.grails.plugins.databasemigration.DatabaseMigrationGrailsPlugin.getDataSourceName
 import static org.grails.plugins.databasemigration.DatabaseMigrationGrailsPlugin.isDefaultDataSource
 import static org.grails.plugins.databasemigration.PluginConstants.DEFAULT_DATASOURCE_NAME
 
@@ -78,10 +77,9 @@ trait ApplicationContextDatabaseMigrationCommand implements DatabaseMigrationCom
     }
 
     private Database createGormDatabase(ConfigurableApplicationContext applicationContext, String dataSource) {
-        String dataSourceName = getDataSourceName(dataSource)
         String sessionFactoryName = "sessionFactory"
         if (!isDefaultDataSource(dataSource)) {
-            sessionFactoryName = sessionFactoryName + '_' + dataSourceName
+            sessionFactoryName = sessionFactoryName + '_' + dataSource
         }
 
         def serviceRegistry = applicationContext.getBean(sessionFactoryName, SessionFactoryImplementor).serviceRegistry.parentServiceRegistry
@@ -89,7 +87,7 @@ trait ApplicationContextDatabaseMigrationCommand implements DatabaseMigrationCom
         Dialect dialect = serviceRegistry.getService(JdbcServices.class).dialect
 
         HibernateDatastore hibernateDatastore = applicationContext.getBean("hibernateDatastore", HibernateDatastore)
-        hibernateDatastore = hibernateDatastore.getDatastoreForConnection(dataSourceName)
+        hibernateDatastore = hibernateDatastore.getDatastoreForConnection(dataSource)
 
         Database database = new GormDatabase(dialect, serviceRegistry, hibernateDatastore)
         configureDatabase(database)


### PR DESCRIPTION
this is a port of grails/grails-database-migration#164 fixing grails/gorm-hibernate5#973 for grails-7 (gorm-hibernate5 `9.0.x` / database-migration `9.0.0-SNAPSHOT`).

i created a sample app to reproduce the issue on grails-7 (blank start.grails.org grails-7.0.0-M1 app, locally built/published `org.grails.plugins:database-migration:9.0.0-SNAPSHOT`):
https://github.com/zyro23/gorm-hibernate5-973/commit/79475d09608b5fe7d4a4a24a63482555d0a26fa4

prior to the changes, running `./grailsw dbm-gorm-diff --dataSource=second` errors with:
```
$ ./grailsw dbm-gorm-diff --dataSource=second

> Task :dbmGormDiff

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.1)

Grails application running at http://localhost:0 in environment: development
Error |
Command execution error: DataSource not found for name [dataSource_second] in configuration. Please check your multiple data sources configuration and try again.
<===========--> 85% EXECUTING [12s]
> :dbmGormDiff

FAILURE: Build failed with an exception.
```

for secondary dataSources, the sessionFactory lookup as well as the hibernateDatastore lookup are now made with the dataSource name without the `dataSource_` prefix.

after applying the changes and re-building/-publishing locally the command succeeds:
```
$ ./grailsw dbm-gorm-diff --dataSource=second

> Task :dbmGormDiff

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.1)

Grails application running at http://localhost:0 in environment: development
BEST PRACTICE: The changelog generated by diffChangeLog/generateChangeLog should be inspected for correctness and completeness before being deployed. Some database objects and their dependencies cannot be represented automatically, and they may need to be manually updated before being deployed.
databaseChangeLog = {
}
```

additional notes regarding the sample app (id say these are separate issues):
* i excluded `liquibase-commercial` explicitly, i do not think it makes sense for grails-database-migration to pull it in via `liquibase-hibernate5` transitively?
  * https://github.com/zyro23/gorm-hibernate5-973/commit/79475d09608b5fe7d4a4a24a63482555d0a26fa4#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R28-R30
* i had to pin `liquibase.version` to `4.27.0` explicitly to prevent boot's blessed version (`4.29.2`) from taking precedence
  * https://github.com/zyro23/gorm-hibernate5-973/commit/79475d09608b5fe7d4a4a24a63482555d0a26fa4#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R32-R34

thanks & regards.