### PR TITLE
Exclude liquibase-commercial from being exported

### DIFF
--- a/grails-database-migration/build.gradle
+++ b/grails-database-migration/build.gradle
@@ -40,12 +40,13 @@ configurations {
 dependencies {
     implementation platform("org.grails:grails-bom:$grailsVersion")
 
-    api "org.liquibase:liquibase-core:$liquibaseHibernate5Version"
+    api("org.liquibase:liquibase-core:$liquibaseHibernate5Version")
     api("org.liquibase.ext:liquibase-hibernate5:$liquibaseHibernate5Version") {
         exclude group: 'org.hibernate', module: 'hibernate-core'
         exclude group: 'org.hibernate', module: 'hibernate-entitymanager'
         exclude group: 'org.hibernate', module: 'hibernate-envers'
         exclude group: 'com.h2database', module: 'h2'
+        exclude group: 'org.liquibase', module: 'liquibase-commercial'
     }
 
     api "org.apache.commons:commons-lang3"


### PR DESCRIPTION
https://github.com/grails/gorm-hibernate5/pull/985 noticed that liquibase-commerical is being pulled in with the refreshed dependencies.  This PR removes it.


`liquibase-commerical` is not Apache licensed and instead uses:  https://www.liquibase.com/eula