### PR TITLE
Fix java.lang.NullPointerException when incorrect schema in database.

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -1505,15 +1505,15 @@ public class GrailsDomainBinder implements MetadataContributor {
                 configureDerivedProperties(sub, subMapping);
             }
         }
-        Integer bs = m.getBatchSize();
+        Integer bs = (m == null) ? null : m.getBatchSize();
         if (bs != null) {
             subClass.setBatchSize(bs);
         }
 
-        if (m.getDynamicUpdate()) {
+        if (m != null && m.getDynamicUpdate()) {
             subClass.setDynamicUpdate(true);
         }
-        if (m.getDynamicInsert()) {
+        if (m != null && m.getDynamicInsert()) {
             subClass.setDynamicInsert(true);
         }
         


### PR DESCRIPTION
org.hibernate.tool.schema.spi.SchemaManagementException expected instead.

This problem is probably present in newer branches too.
