### PR TITLE
remove groovyVersion from gradle.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     nexusUsername = System.getenv("SONATYPE_USERNAME") ?: project.hasProperty("sonatypeOssUsername") ? project.sonatypeOssUsername : ''
     nexusPassword = System.getenv("SONATYPE_PASSWORD") ?: project.hasProperty("sonatypeOssPassword") ? project.sonatypeOssPassword : ''
     isSnapshot = project.projectVersion.endsWith("-SNAPSHOT")
-    groovyVersion = System.getenv('CI_GROOVY_VERSION') ?: project.groovyVersion
+    groovyVersion = System.getenv('CI_GROOVY_VERSION')
 }
 
 ext."signing.keyId" = System.getenv("SIGNING_KEY") ?: project.hasProperty("signing.keyId") ? project.getProperty('signing.keyId') : null
@@ -51,7 +51,7 @@ if (isReleaseVersion) {
 
 allprojects {
 
-    ext.groovyVersion = System.getenv('CI_GROOVY_VERSION') ?: project.groovyVersion
+    ext.groovyVersion = System.getenv('CI_GROOVY_VERSION')
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,10 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
+        classpath platform("org.grails:grails-bom:$grailsVersion")
         classpath "io.github.gradle-nexus:publish-plugin:$gradleNexusPublishPluginVersion"
-        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
-        classpath "org.grails.plugins:views-gradle:$viewsGradleVersion"
+        classpath "org.grails:grails-gradle-plugin"
+        classpath "org.grails.plugins:views-gradle"
         classpath "org.asciidoctor:asciidoctor-gradle-jvm:$asciidoctorGradleVersion"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ gormVersion=9.0.0-M2
 gradleNexusPublishPluginVersion=2.0.0
 grailsGradlePluginVersion=7.0.0-M2
 grailsVersion=7.0.0-M1
-groovyVersion=4.0.24
 hibernateVersion=5.6.15.Final
 liquibaseHibernate5Version=4.27.0
 jbossTransactionApiVersion=2.0.0.Final

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 projectVersion=9.0.0-SNAPSHOT
 asciidoctorGradleVersion=4.0.3
-gormVersion=9.0.0-M2
+gormVersion=9.0.0-SNAPSHOT
 gradleNexusPublishPluginVersion=2.0.0
-grailsGradlePluginVersion=7.0.0-M2
-grailsVersion=7.0.0-M1
+grailsGradlePluginVersion=7.0.0-SNAPSHOT
+grailsVersion=7.0.0-SNAPSHOT
 hibernateVersion=5.6.15.Final
 liquibaseHibernate5Version=4.27.0
 jbossTransactionApiVersion=2.0.0.Final
@@ -11,7 +11,7 @@ yakworksHibernateGroovyProxyVersion=1.1
 micronautPlatformVersion=4.6.3
 picocliVersion=4.7.6
 springBootGradlePluginVersion=3.4.1
-viewsGradleVersion=4.0.0-M1
+viewsGradleVersion=4.0.0-SNAPSHOT
 
 org.gradle.caching=true
 org.gradle.parallel=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ projectVersion=9.0.0-SNAPSHOT
 asciidoctorGradleVersion=4.0.3
 gormVersion=9.0.0-SNAPSHOT
 gradleNexusPublishPluginVersion=2.0.0
-grailsGradlePluginVersion=7.0.0-SNAPSHOT
 grailsVersion=7.0.0-SNAPSHOT
 hibernateVersion=5.6.15.Final
 liquibaseHibernate5Version=4.27.0
@@ -10,8 +9,7 @@ jbossTransactionApiVersion=2.0.0.Final
 yakworksHibernateGroovyProxyVersion=1.1
 micronautPlatformVersion=4.6.3
 picocliVersion=4.7.6
-springBootGradlePluginVersion=3.4.1
-viewsGradleVersion=4.0.0-SNAPSHOT
+springBootGradlePluginVersion=3.4.2
 
 org.gradle.caching=true
 org.gradle.parallel=false

--- a/grails-database-migration/build.gradle
+++ b/grails-database-migration/build.gradle
@@ -3,7 +3,8 @@ buildscript {
         maven { url "https://repo.grails.org/grails/core" }
     }
     dependencies {
-        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+        classpath platform("org.grails:grails-bom:$grailsVersion")
+        classpath "org.grails:grails-gradle-plugin"
         classpath "org.asciidoctor:asciidoctor-gradle-jvm:$asciidoctorGradleVersion"
     }
 }


### PR DESCRIPTION
`groovyVersion = System.getenv('CI_GROOVY_VERSION')` is still used in the joint workflow, but reads from the groovy git repository.  