### PR TITLE
use GrailsStringUtils.trimToNull() instead of apache commons version

### DIFF
--- a/grails-database-migration/build.gradle
+++ b/grails-database-migration/build.gradle
@@ -29,7 +29,7 @@ dependencies {
         exclude group: 'com.h2database', module: 'h2'
         exclude group: 'org.liquibase', module: 'liquibase-commercial'
     }
-    api 'org.apache.commons:commons-lang3'
+
     api('org.grails:grails-shell') {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }
@@ -37,11 +37,13 @@ dependencies {
     compileOnly "org.springframework.boot:spring-boot-starter-logging"
     compileOnly "org.springframework.boot:spring-boot-autoconfigure"
     compileOnly "org.grails.plugins:hibernate5"
+    compileOnly "org.grails:grails-core"
     compileOnly "org.apache.groovy:groovy-sql"
     compileOnly "org.apache.groovy:groovy-xml"
 
     testImplementation "org.springframework.boot:spring-boot-starter-tomcat"
     testImplementation "org.grails.plugins:hibernate5"
+    testImplementation "org.grails:grails-core"
     testImplementation "org.grails:grails-gorm-testing-support"
     testImplementation "org.grails:grails-web-testing-support"
     testImplementation "com.h2database:h2"

--- a/grails-database-migration/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyDiffToChangeLogCommandStep.groovy
+++ b/grails-database-migration/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyDiffToChangeLogCommandStep.groovy
@@ -28,7 +28,7 @@ import liquibase.database.ObjectQuotingStrategy
 import liquibase.diff.DiffResult
 import liquibase.diff.output.DiffOutputControl
 import liquibase.serializer.ChangeLogSerializerFactory
-import org.apache.commons.lang3.StringUtils
+import grails.util.GrailsStringUtils
 
 @CompileStatic
 class GroovyDiffToChangeLogCommandStep extends DiffChangelogCommandStep {
@@ -55,7 +55,7 @@ class GroovyDiffToChangeLogCommandStep extends DiffChangelogCommandStep {
 
         try {
             referenceDatabase.setObjectQuotingStrategy(ObjectQuotingStrategy.QUOTE_ALL_OBJECTS);
-            if (StringUtils.trimToNull(changeLogFile) == null) {
+            if (GrailsStringUtils.trimToNull(changeLogFile) == null) {
                 createDiffToChangeLogObject(diffResult, diffOutputControl, false).print(outputStream, ChangeLogSerializerFactory.instance.getSerializer('groovy'))
             } else {
                 createDiffToChangeLogObject(diffResult, diffOutputControl, false).print(changeLogFile, ChangeLogSerializerFactory.instance.getSerializer(changeLogFile))

--- a/grails-database-migration/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyGenerateChangeLogCommandStep.groovy
+++ b/grails-database-migration/src/main/groovy/org/grails/plugins/databasemigration/liquibase/GroovyGenerateChangeLogCommandStep.groovy
@@ -30,7 +30,7 @@ import liquibase.diff.DiffResult
 import liquibase.diff.output.DiffOutputControl
 import liquibase.diff.output.changelog.DiffToChangeLog
 import liquibase.serializer.ChangeLogSerializerFactory
-import org.apache.commons.lang3.StringUtils
+import grails.util.GrailsStringUtils
 
 @CompileStatic
 class GroovyGenerateChangeLogCommandStep extends GenerateChangelogCommandStep {
@@ -46,7 +46,7 @@ class GroovyGenerateChangeLogCommandStep extends GenerateChangelogCommandStep {
     void run(CommandResultsBuilder resultsBuilder) throws Exception {
         CommandScope commandScope = resultsBuilder.getCommandScope();
 
-        String changeLogFile = StringUtils.trimToNull(commandScope.getArgumentValue(CHANGELOG_FILE_ARG));
+        String changeLogFile = GrailsStringUtils.trimToNull(commandScope.getArgumentValue(CHANGELOG_FILE_ARG));
         if (changeLogFile != null && changeLogFile.toLowerCase().endsWith(".sql")) {
             Scope.getCurrentScope().getUI().sendMessage("\n" + INFO_MESSAGE + "\n");
             Scope.getCurrentScope().getLog(getClass()).info("\n" + INFO_MESSAGE + "\n");
@@ -71,7 +71,7 @@ class GroovyGenerateChangeLogCommandStep extends GenerateChangelogCommandStep {
         ObjectQuotingStrategy originalStrategy = referenceDatabase.getObjectQuotingStrategy();
         try {
             referenceDatabase.setObjectQuotingStrategy(ObjectQuotingStrategy.QUOTE_ALL_OBJECTS);
-            if (StringUtils.trimToNull(changeLogFile) != null) {
+            if (GrailsStringUtils.trimToNull(changeLogFile) != null) {
                 changeLogWriter.print(changeLogFile, ChangeLogSerializerFactory.instance.getSerializer(changeLogFile))
             } else {
                 PrintStream outputStream = new PrintStream(resultsBuilder.getOutputStream());
@@ -82,7 +82,7 @@ class GroovyGenerateChangeLogCommandStep extends GenerateChangelogCommandStep {
                 }
 
             }
-            if (StringUtils.trimToNull(changeLogFile) != null) {
+            if (GrailsStringUtils.trimToNull(changeLogFile) != null) {
                 Scope.getCurrentScope().getUI().sendMessage("Generated changelog written to " + new File(changeLogFile).getAbsolutePath());
             }
         } finally {


### PR DESCRIPTION
https://github.com/grails/grails-core/pull/13807


This was based on an objective to remove "commons-lang" or "commons-text" where Grails is only using a small number of methods.

Enables api 'org.apache.commons:commons-lang3:3.17.0' to be removed from grails-database-migration.

https://github.com/search?q=repo%3Agrails%2Fgrails-database-migration%20StringUtils&type=code

